### PR TITLE
Sprint3 replace word

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,6 @@ Unit testing is working in Visual Studio Enterprise so the function can be run t
 
 First Sprint: count words between tokens
 Second sprint: count lines and characters
+Third sprint: replace words (case sensitive and whole words only) 
 
 To run this code, you can execute main.py.  It will bring up a while true loop that accepts input and spits out statistics

--- a/README.md
+++ b/README.md
@@ -1,23 +1,24 @@
 # Sp23_CS5103_wde677
-CS 5103 Course Project: Software Engineering Practice
+# Bobb Shields
+# wde677
 
-Delivery 
+##CS 5103 Course Project: Software Engineering Practice##
 
-We will have two mid-term check points due on Mar. 10th and Mar. 31th after two  development sprints, and the final due date will be Apr 28th.  
-
-Due on Mar. 10th: Requirements, implementation (with repo link), unit tests, and readme file (describing how to run your code) for the first batch of requirement. 
-Due to Mar. 31th: Requirements, implementation (with the same repo link), unit tests, and readme file (describing how to run your code) for the second batch of requirement. 
-Due on Apr. 28th: Requirements, implementation (with repo link), readme file, for the last batch of requirement, design change report (reporting the design principles and design  
+Schedule: 
+Mar. 10th: Requirements, implementation (with repo link), unit tests, and readme file (describing how to run your code) for the first batch of requirement. 
+Mar. 31th: Requirements, implementation (with the same repo link), unit tests, and readme file (describing how to run your code) for the second batch of requirement. 
+Apr. 28th: Requirements, implementation (with repo link), readme file, for the last batch of requirement, design change report (reporting the design principles and design  
 patterns you used if any), tool application report (reporting the results and experience of using automatic tools mentioned above). 
 
-Example:
+Code Example:
 from word_stats import count_words
 print_stats("I love coding.  Don't you love coding?")
 
-Unit testing is working in Visual Studio Enterprise so the function can be run through those ringers too
+Unit testing is working in Visual Studio Enterprise 
 
 First Sprint: count words between tokens
 Second sprint: count lines and characters
 Third sprint: replace words (case sensitive and whole words only) 
 
-To run this code, you can execute main.py.  It will bring up a while true loop that accepts input and spits out statistics
+To run this code, you can execute main.py.  It will print out a few examples then bring up a while true loop that accepts input and spits out statistics.
+Enter \q to this prompt to quit. 

--- a/main.py
+++ b/main.py
@@ -7,6 +7,9 @@ import word_stats
 
 print(word_stats.print_stats("This is a general test of the broadcast system.\n Please return to your homes\n 1234 5678\n"))
 
+#The FFF THE FFFe three
+print(word_stats.replace_word("The the THE thee three", "the", "FFF") )
+
 #infinite while loop, easily broken out of 
 while True:
     input_text = input("Enter text to analyze (or '\q' to exit): ")

--- a/main.py
+++ b/main.py
@@ -5,11 +5,14 @@
 # Allows a single call to activate the whole stats suite
 import word_stats
 
+print("This is a general test of the broadcast system.\n Please return to your homes\n 1234 5678\n")
 print(word_stats.print_stats("This is a general test of the broadcast system.\n Please return to your homes\n 1234 5678\n"))
 
 #The FFF THE FFFe three
-print("\"The the THE thee three\" \'the\'")
+print("***")
+print("Replace Words:\n\"The the THE thee three\" \'the\' - \'FFF\'")
 print(word_stats.replace_word("The the THE thee three", "the", "FFF") )
+print("***")
 
 #infinite while loop, easily broken out of 
 while True:

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ import word_stats
 print(word_stats.print_stats("This is a general test of the broadcast system.\n Please return to your homes\n 1234 5678\n"))
 
 #The FFF THE FFFe three
+print("\"The the THE thee three\" \'the\'")
 print(word_stats.replace_word("The the THE thee three", "the", "FFF") )
 
 #infinite while loop, easily broken out of 

--- a/main.py
+++ b/main.py
@@ -2,7 +2,11 @@
 # wde677
 #
 
-# Allows a single call to activate the whole stats suite
+# Unit testing code for word statistics functions
+# First sprint: count_words
+# Second sprint: count_lines, count_chars, check_input, test scenarios
+# Third sprint: replace_word, check_input([list])
+
 import word_stats
 
 print("This is a general test of the broadcast system.\n Please return to your homes\n 1234 5678\n")

--- a/test_word_stats.py
+++ b/test_word_stats.py
@@ -30,7 +30,7 @@ class TestInputChecking(unittest.TestCase):
             count_lines(doc)
 
     def test_almost_maximum_length(self): #User case: Data Scientist max limit concerns
-        doc = "A" * 10000
+        doc = "A" * 9999
         self.assertTrue(check_input(doc))
     
     def test_is_string(self): 
@@ -44,7 +44,7 @@ class TestInputChecking(unittest.TestCase):
 
     def test_null_list(self): 
         doc = ["","test2"]
-        with self.assertRaisesRegex(TypeError, "Input cannot be empty"):
+        with self.assertRaisesRegex(ValueError, "Input cannot be empty"):
             check_input(doc)
 
 # Word Count Test Code
@@ -152,11 +152,6 @@ class TestScenarios(unittest.TestCase):
 # Replace Word Test Code
 # 
 class TestWordReplace(unittest.TestCase):
-    def test_replace_normal(self):
-        doc = "The quick brown fox jumped over the lazy dog, but the 1 dog didn't care. The fox was too fast for the 2 dogs to catch, and they could only watch as it disappeared into the distance. However, the 3rd dog was smarter than the others and knew a shortcut;\n\n it ran ahead and caught the fox by surprise! \"What's going on here?\" the fox asked. But the dog just barked in triumph, knowing that it had won the race.\n\n Meanwhile, the lazy dog snoozed on, oblivious to the excitement happening around it.\n + = % $ \n\n fin fin."        
-        expected_output = "The quick brown fox jumped over THE lazy dog, but THE 1 dog didn't care. The fox was too fast for THE 2 dogs to catch, and THEy could only watch as it disappeared into THE distance. However, THE 3rd dog was smarter than THE oTHErs and knew a shortcut;\n\n it ran ahead and caught THE fox by surprise! \"What's going on here?\" THE fox asked. But THE dog just barked in triumph, knowing that it had won THE race.\n\n Meanwhile, THE lazy dog snoozed on, oblivious to THE excitement happening around it.\n + = % $ \n\n fin fin."        
-        self.assertEqual(replace_word(doc,"the", "THE"), expected_output)
-
     def test_distinct_words_1(self):
         doc = "The the THE thee three"
         expected_output = "FFF the THE thee three"

--- a/test_word_stats.py
+++ b/test_word_stats.py
@@ -16,10 +16,6 @@ from word_stats import check_input
 from word_stats import replace_word 
 from word_stats import print_stats
 
-#not sure what this is but afraid to delete it since unittest.(RELATED)
-if __name__ == '__main__':
-    unittest.main()
-
 # Input checking Test Code
 #
 class TestInputChecking(unittest.TestCase):
@@ -175,3 +171,10 @@ class TestWordReplace(unittest.TestCase):
         doc = "The the THE thee three"
         expected_output = "The the FFF thee three"
         self.assertEqual(replace_word(doc, "THE", "FFF"), expected_output)
+
+
+
+#https://mattermost.com/blog/how-to-unit-test-with-python/
+#this piece of code is needed at the end as per the above website
+if __name__ == '__main__':
+    unittest.main()

--- a/test_word_stats.py
+++ b/test_word_stats.py
@@ -41,6 +41,15 @@ class TestInputChecking(unittest.TestCase):
         doc = 1000
         with self.assertRaisesRegex(TypeError, "Input must be a string"):
             check_input(doc)
+    
+    def test_good_list(self): 
+        doc = ["test","test2"]
+        self.assertTrue(check_input(doc))
+
+    def test_null_list(self): 
+        doc = ["","test2"]
+        with self.assertRaisesRegex(TypeError, "Input cannot be empty"):
+            check_input(doc)
 
 # Word Count Test Code
 #
@@ -144,12 +153,25 @@ class TestScenarios(unittest.TestCase):
         except:
             self.fail("Unexpected exception was raised.")                  
 
-#Third Sprint: Word Statistics: The second requirement change is to allow replacement of all occurrences of a 
-#given word to a given replacement word. Note that the replacement happens only when the given pattern word 
-#matches with a whole word. For example, for text “ab cd ef”, replace “a” with “b” will result in no change, 
-#while replace “ab” with “cd” will result in “cd cd ef”. 
+# Replace Word Test Code
+# 
 class TestWordReplace(unittest.TestCase):
     def test_replace_normal(self):
         doc = "The quick brown fox jumped over the lazy dog, but the 1 dog didn't care. The fox was too fast for the 2 dogs to catch, and they could only watch as it disappeared into the distance. However, the 3rd dog was smarter than the others and knew a shortcut;\n\n it ran ahead and caught the fox by surprise! \"What's going on here?\" the fox asked. But the dog just barked in triumph, knowing that it had won the race.\n\n Meanwhile, the lazy dog snoozed on, oblivious to the excitement happening around it.\n + = % $ \n\n fin fin."        
         expected_output = "The quick brown fox jumped over THE lazy dog, but THE 1 dog didn't care. The fox was too fast for THE 2 dogs to catch, and THEy could only watch as it disappeared into THE distance. However, THE 3rd dog was smarter than THE oTHErs and knew a shortcut;\n\n it ran ahead and caught THE fox by surprise! \"What's going on here?\" THE fox asked. But THE dog just barked in triumph, knowing that it had won THE race.\n\n Meanwhile, THE lazy dog snoozed on, oblivious to THE excitement happening around it.\n + = % $ \n\n fin fin."        
         self.assertEqual(replace_word(doc,"the", "THE"), expected_output)
+
+    def test_distinct_words_1(self):
+        doc = "The the THE thee three"
+        expected_output = "FFF the THE thee three"
+        self.assertEqual(replace_word("The the THE thee three", "The", "FFF"), expected_output)
+
+    def test_distinct_words_2(self):
+        doc = "The the THE thee three"
+        expected_output = "The FFF THE thee three"
+        self.assertEqual(replace_word("The the THE thee three", "the", "FFF"), expected_output)
+
+    def test_distinct_words_3(self):
+        doc = "The the THE thee three"
+        expected_output = "The the FFF thee three"
+        self.assertEqual(replace_word("The the THE thee three", "THE", "FFF"), expected_output)

--- a/test_word_stats.py
+++ b/test_word_stats.py
@@ -4,8 +4,8 @@
 
 # Unit testing code for word statistics functions
 # First sprint: count_words
-# Second sprint: count_lines, count_chars
-#
+# Second sprint: count_lines, count_chars, check_input, test scenarios
+# Third sprint: replace_word, check_input([list])
 
 
 import unittest
@@ -169,7 +169,8 @@ class TestWordReplace(unittest.TestCase):
 
 
 
+
+#this piece of code belongs at the bottom as per the this article
 #https://mattermost.com/blog/how-to-unit-test-with-python/
-#this piece of code is needed at the end as per the above website
 if __name__ == '__main__':
     unittest.main()

--- a/test_word_stats.py
+++ b/test_word_stats.py
@@ -15,6 +15,10 @@ from word_stats import count_chars
 from word_stats import check_input 
 from word_stats import print_stats
 
+#not sure what this is but afraid to delete it since unittest.(RELATED)
+if __name__ == '__main__':
+    unittest.main()
+
 # Input checking Test Code
 #
 class TestInputChecking(unittest.TestCase):
@@ -139,6 +143,5 @@ class TestScenarios(unittest.TestCase):
         except:
             self.fail("Unexpected exception was raised.")                  
 
-if __name__ == '__main__':
-    unittest.main()
+
 

--- a/test_word_stats.py
+++ b/test_word_stats.py
@@ -13,6 +13,7 @@ from word_stats import count_words  # Import the count_words function from the w
 from word_stats import count_lines
 from word_stats import count_chars  
 from word_stats import check_input 
+from word_stats import replace_word 
 from word_stats import print_stats
 
 #not sure what this is but afraid to delete it since unittest.(RELATED)
@@ -143,5 +144,12 @@ class TestScenarios(unittest.TestCase):
         except:
             self.fail("Unexpected exception was raised.")                  
 
-
-
+#Third Sprint: Word Statistics: The second requirement change is to allow replacement of all occurrences of a 
+#given word to a given replacement word. Note that the replacement happens only when the given pattern word 
+#matches with a whole word. For example, for text “ab cd ef”, replace “a” with “b” will result in no change, 
+#while replace “ab” with “cd” will result in “cd cd ef”. 
+class TestWordReplace(unittest.TestCase):
+    def test_replace_normal(self):
+        doc = "The quick brown fox jumped over the lazy dog, but the 1 dog didn't care. The fox was too fast for the 2 dogs to catch, and they could only watch as it disappeared into the distance. However, the 3rd dog was smarter than the others and knew a shortcut;\n\n it ran ahead and caught the fox by surprise! \"What's going on here?\" the fox asked. But the dog just barked in triumph, knowing that it had won the race.\n\n Meanwhile, the lazy dog snoozed on, oblivious to the excitement happening around it.\n + = % $ \n\n fin fin."        
+        expected_output = "The quick brown fox jumped over THE lazy dog, but THE 1 dog didn't care. The fox was too fast for THE 2 dogs to catch, and THEy could only watch as it disappeared into THE distance. However, THE 3rd dog was smarter than THE oTHErs and knew a shortcut;\n\n it ran ahead and caught THE fox by surprise! \"What's going on here?\" THE fox asked. But THE dog just barked in triumph, knowing that it had won THE race.\n\n Meanwhile, THE lazy dog snoozed on, oblivious to THE excitement happening around it.\n + = % $ \n\n fin fin."        
+        self.assertEqual(replace_word(doc,"the", "THE"), expected_output)

--- a/test_word_stats.py
+++ b/test_word_stats.py
@@ -164,14 +164,14 @@ class TestWordReplace(unittest.TestCase):
     def test_distinct_words_1(self):
         doc = "The the THE thee three"
         expected_output = "FFF the THE thee three"
-        self.assertEqual(replace_word("The the THE thee three", "The", "FFF"), expected_output)
+        self.assertEqual(replace_word(doc, "The", "FFF"), expected_output)
 
     def test_distinct_words_2(self):
         doc = "The the THE thee three"
         expected_output = "The FFF THE thee three"
-        self.assertEqual(replace_word("The the THE thee three", "the", "FFF"), expected_output)
+        self.assertEqual(replace_word(doc, "the", "FFF"), expected_output)
 
     def test_distinct_words_3(self):
         doc = "The the THE thee three"
         expected_output = "The the FFF thee three"
-        self.assertEqual(replace_word("The the THE thee three", "THE", "FFF"), expected_output)
+        self.assertEqual(replace_word(doc, "THE", "FFF"), expected_output)

--- a/word_stats.py
+++ b/word_stats.py
@@ -24,15 +24,24 @@ def print_stats(text):
 #
 def check_input(text):
 
-    if not isinstance(text, str):
-        raise TypeError("Input must be a string")
+    #if input is a single string, save as a list
+    if isinstance(text, str):
+        text_list = [text]
+    elif isinstance(text, list):
+        text_list = text
+    else:
+        raise TypeError("Input must be a string or a list")
 
-    if (text==""):
-        raise ValueError("Input cannot be empty")
+    for text in text_list:
+        if not isinstance(text, str):
+            raise TypeError("Elements in list must be strings")
 
-    if (len(text)>=10000):
-        print(text)
-        raise ValueError("Input exceeds maximum length")
+        if text == "":
+            raise ValueError("Input cannot be empty")
+
+        if len(text) >= 10000:
+            print(text)
+            raise ValueError("Input exceeds maximum length")
     
     return True
 
@@ -105,9 +114,8 @@ def count_chars(text): #CharCount is simply the length of the text field.
 #
 def replace_word(text, find, replace):
     #check input and it will throw errors if needed
-    check_input(text)
-    check_input(find)
-    check_input(replace)
+    check_list = [text, find, replace]
+    check_input(check_list)
 
    # use regular expression to match whole words only
     pattern = r'\b{}\b'.format(re.escape(find))

--- a/word_stats.py
+++ b/word_stats.py
@@ -74,7 +74,7 @@ def count_words(text):
 # Count of the lines.  
 # (Counting the new strings)
 #
-def count_lines (text): #looks for all “\n” tokens in the given string
+def count_lines (text): #looks for all \n tokens in the given string
     #check input and it will throw errors if needed
     check_input(text)
 
@@ -104,8 +104,8 @@ def count_chars(text): #CharCount is simply the length of the text field.
 
 #Third Sprint: Word Statistics: The second requirement change is to allow replacement of all occurrences of a 
 #given word to a given replacement word. Note that the replacement happens only when the given pattern word 
-#matches with a whole word. For example, for text “ab cd ef”, replace “a” with “b” will result in no change, 
-#while replace “ab” with “cd” will result in “cd cd ef”. 
+#matches with a whole word. For example, for text "ab cd ef", replace "a" with "b" will result in no change, 
+#while replace "ab" with "cd" will result in "cd cd ef". 
 
 #similar to count_words, but 
 

--- a/word_stats.py
+++ b/word_stats.py
@@ -4,13 +4,14 @@
 
 # Stats for text passed in as the singular parameter
 # First sprint: count_words
-# Second sprint: count_lines, count_chars
-#
+# Second sprint: count_lines, count_chars, check_input
+# Third sprint: replace_word, check_input([list])
+
 import string
 import re
 
-# Combine all the functions together in one function, for ease   
-# 
+# Combine function calls with same parameter together to print and label 
+# Just a courtesy 
 #
 def print_stats(text):
 
@@ -19,7 +20,7 @@ def print_stats(text):
             "Word Counts by freq:\n" + str(count_words(text) )
         )
 
-# Global input bounds checker that throws errors if failed  
+# Global input bounds checker that throws specific errors if failed  
 # 
 #
 def check_input(text):
@@ -72,7 +73,7 @@ def count_words(text):
     return sorted_word_counts
 
 # Count of the lines.  
-# (Counting the new strings)
+# number of new line characters + 1 
 #
 def count_lines (text): #looks for all \n tokens in the given string
     #check input and it will throw errors if needed
@@ -86,7 +87,7 @@ def count_lines (text): #looks for all \n tokens in the given string
 
     return line_count
 
-# Count of the individual characters.  
+# Count of the individual characters
 # Whitespace removed (space, tab, linefeed, return, formfeed, and vertical tab)
 #
 def count_chars(text): #CharCount is simply the length of the text field.
@@ -101,27 +102,16 @@ def count_chars(text): #CharCount is simply the length of the text field.
 
     return char_count
 
-
-#Third Sprint: Word Statistics: The second requirement change is to allow replacement of all occurrences of a 
-#given word to a given replacement word. Note that the replacement happens only when the given pattern word 
-#matches with a whole word. For example, for text "ab cd ef", replace "a" with "b" will result in no change, 
-#while replace "ab" with "cd" will result in "cd cd ef". 
-
-#similar to count_words, but 
-
-# Count of the individual words.  
-# All characters pushed to lowercase as to make this case insensitive
-#
+# Replace a word within a string.  
+# Uses regular expression to evaluate against the whole word
+# Adding ", flags=re.IGNORECASE" as arg to re.sub() affects case sensitivity 
 def replace_word(text, find, replace):
-    #check input and it will throw errors if needed
+    #check inputs and it will throw errors if needed
     check_list = [text, find, replace]
     check_input(check_list)
 
    # use regular expression to match whole words only
     pattern = r'\b{}\b'.format(re.escape(find))
-    text = re.sub(pattern, replace, text )# , flags=re.IGNORECASE)
-    
-    return text
+    text = re.sub(pattern, replace, text ) # <- Case sentitivity flag goes here if needed in future
 
-#print(word_stats.replace_word("The the THE thee three", "the", "FFF") )
-#problem: #The FFF THE FFFe three
+    return text

--- a/word_stats.py
+++ b/word_stats.py
@@ -18,7 +18,7 @@ def print_stats(text):
             "Word Counts by freq:\n" + str(count_words(text) )
         )
 
-# One function, near the top, that enables input error checking for all functions  
+# Global input bounds checker that throws errors if failed  
 # 
 #
 def check_input(text):
@@ -90,3 +90,28 @@ def count_chars(text): #CharCount is simply the length of the text field.
             char_count += 1
 
     return char_count
+
+
+#Third Sprint: Word Statistics: The second requirement change is to allow replacement of all occurrences of a 
+#given word to a given replacement word. Note that the replacement happens only when the given pattern word 
+#matches with a whole word. For example, for text “ab cd ef”, replace “a” with “b” will result in no change, 
+#while replace “ab” with “cd” will result in “cd cd ef”. 
+
+#similar to count_words, but 
+
+# Count of the individual words.  
+# All characters pushed to lowercase as to make this case insensitive
+#
+def replace_word(text, find, replace):
+    #check input and it will throw errors if needed
+    check_input(text)
+    check_input(find)
+    check_input(replace)
+
+    # replace tabs and newlines with spaces
+    text = text.replace(find, replace)
+    
+    return text
+
+#problem: #The FFF THE FFFe three
+#print(word_stats.replace_word("The the THE thee three", "the", "FFF") )

--- a/word_stats.py
+++ b/word_stats.py
@@ -7,6 +7,7 @@
 # Second sprint: count_lines, count_chars
 #
 import string
+import re
 
 # Combine all the functions together in one function, for ease   
 # 
@@ -108,10 +109,11 @@ def replace_word(text, find, replace):
     check_input(find)
     check_input(replace)
 
-    # replace tabs and newlines with spaces
-    text = text.replace(find, replace)
+   # use regular expression to match whole words only
+    pattern = r'\b{}\b'.format(re.escape(find))
+    text = re.sub(pattern, replace, text )# , flags=re.IGNORECASE)
     
     return text
 
-#problem: #The FFF THE FFFe three
 #print(word_stats.replace_word("The the THE thee three", "the", "FFF") )
+#problem: #The FFF THE FFFe three


### PR DESCRIPTION
Replace word functionality is ready for thorough testing.  Need to review requirements one more time but function now works on singular words instead of subsets of the words.  Using regular expressions to make that happen.  Chose to keep it case sensitive for now but left notes on how to change that flag.  